### PR TITLE
feat(server): Employee can delete their own articles

### DIFF
--- a/api/v1/controllers/articleController.js
+++ b/api/v1/controllers/articleController.js
@@ -110,5 +110,33 @@ export default {
         } catch (error) {
             res.status(400).json(error)
         }
+    },
+    async delete(req, res) {
+        const { articleId } = req.params
+        const token = res.token
+        const item = articles.find(article => article.id == articleId)
+
+        const validId = articles.findIndex(article => article.id == articleId)
+        if (validId === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "article does not exist"
+            });
+        }
+        if (token.id !== item.owner) throw res.status(405).send({
+            status: 405,
+            message: "you have no rights over this property"
+        });
+
+        const brp = categories.filter(obj => obj.articleId == articleId)
+        const cmnt = comments.filter(obj => obj.articleId == articleId)
+        articles.splice(validId, 1)
+        brp.forEach(f => categories.splice(categories.findIndex(e => e.articleId == f.articleId), 1))
+        cmnt.forEach(f => comments.splice(comments.findIndex(e => e.articleId == f.articleId), 1))
+
+        res.status(200).json({
+            status: 200,
+            message: 'article successfully deleted'
+        })
     }
 }

--- a/api/v1/routes/article.js
+++ b/api/v1/routes/article.js
@@ -9,5 +9,6 @@ router.post("/articles", jwt, createArticle, articleController.create);
 router.patch("/articles/:articleId", jwt, updateArticle, articleController.update);
 router.get("/feeds", jwt, articleController.get_all);
 router.get("/articles/:articleId", jwt, articleController.get_one);
+router.delete("/articles/:articleId", jwt, articleController.delete);
 
 export default router;


### PR DESCRIPTION
### What does this PR do ?
- Employee can delete their own articles
- delete also comments assiciated with that article
- delete also categories assiciated with that article
- validations if own its own article
### Description of tasks to be completed ?
Have the following endpoint working
- DELETE /api/v1/articles/<articleId>
### How should this be manually tested ?
After cloning this repo, od into it and run `npm start` in the terminal
- using postman test the above endpoint with this header
key: Content-type value: application/json
- to test authantication, add this to the header: Get TOKEN from login endpoint
key: token value: JWT TOKEN
### Any background context you want to provide ?
N/A
### What are the relevant PivotTracker stories ?
#168388180