### PR TITLE
feat(server): Admin can Ignore(delete) a flag

### DIFF
--- a/api/v1/controllers/adminIgnoreController.js
+++ b/api/v1/controllers/adminIgnoreController.js
@@ -1,0 +1,35 @@
+import articleFlags from "../models/articleFlag";
+import commentFlags from "../models/commentFlag";
+
+export default {
+    async article(req, res) {
+        const { flagId } = req.params
+        const validId = articleFlags.findIndex(article => article.id == flagId)
+        if (validId === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "flag does not exist"
+            });
+        }
+        articleFlags.splice(validId, 1)
+        res.status(204).json({
+            status: 204,
+            massage: "flagged article successfully deleted"
+        })
+    },
+    async comment(req, res) {
+        const { flagId } = req.params
+        const validId = commentFlags.findIndex(article => article.id == flagId)
+        if (validId === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "flag does not exist"
+            });
+        }
+        commentFlags.splice(validId, 1)
+        res.status(200).json({
+            status: 204,
+            massage: "flagged comment successfully deleted"
+        })
+    },
+}

--- a/api/v1/routes/admin.js
+++ b/api/v1/routes/admin.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import adminController from '../controllers/adminController'
+import adminIgnoreController from '../controllers/adminIgnoreController'
 import admin from "../middlewares/adminValidation/admin"
 
 import jwt from "../middlewares/jwt"
@@ -7,5 +8,10 @@ import jwt from "../middlewares/jwt"
 const router = express.Router()
 router.get("/admin/articles", jwt, admin, adminController.fetch_article)
 router.get("/admin/comments", jwt, admin, adminController.fetch_comment)
+
+// -------------- Admin can ignore flagged ----------------------
+
+router.delete("/admin/:flagId/ignore/articles", jwt, admin, adminIgnoreController.article)
+router.delete("/admin/:flagId/ignore/comments", jwt, admin, adminIgnoreController.comment)
 
 export default router


### PR DESCRIPTION
### What does this PR do ?
- admin can delete an article flag
- admin can delete a comment flag
- response to the user
### Description of tasks to be completed ?
Have the following endpoint working
- DELETE /admin/`:flagId`/ignore/articles
- DELETE /admin/`:flagId`/ignore/comments
### How should this be manually tested ?
After cloning this repo, od into it and run `npm start` in the terminal
- using postman test the above endpoints with this header
key: Content-type value: application/json
- to test authantication, add this to the header: Get TOKEN from login endpoint
key: token value: JWT TOKEN
### Any background context you want to provide ?
N/A
### What are the relevant PivotTracker stories ?
#168388684