### PR TITLE
feat(server): Admin can delete flagged items

### DIFF
--- a/api/v1/controllers/adminDeleteController.js
+++ b/api/v1/controllers/adminDeleteController.js
@@ -1,0 +1,64 @@
+import articleFlags from "../models/articleFlag"
+import articles from "../models/article"
+import categories from "../models/category"
+import comments from '../models/comment'
+import commentFlags from "../models/commentFlag"
+
+
+export default {
+    async article(req, res) {
+        const { flagId } = req.params
+        const validFlag = articleFlags.findIndex(article => article.id == flagId)
+        if (validFlag === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "flag does not exist"
+            });
+        }
+        const findFlag = articleFlags.find(x => x.id == flagId)
+        const articleId = findFlag.articleId
+        const item = articles.find(article => article.id == articleId)
+
+        const validId = articles.findIndex(article => article.id == articleId)
+        if (validId === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "article does not exist"
+            });
+        }
+
+        const brp = categories.filter(obj => obj.articleId == articleId)
+        const cmnt = comments.filter(obj => obj.articleId == articleId)
+        const flgz = articleFlags.filter(obj => obj.articleId == articleId)
+        articles.splice(validId, 1)
+        brp.forEach(f => categories.splice(categories.findIndex(e => e.articleId == f.articleId), 1))
+        cmnt.forEach(f => comments.splice(comments.findIndex(e => e.articleId == f.articleId), 1))
+        flgz.forEach(f => articleFlags.splice(articleFlags.findIndex(e => e.articleId == f.articleId), 1))
+
+        res.status(200).json({
+            status: 200,
+            message: 'article successfully deleted and every thing assiciated'
+        })
+
+    },
+    async comment(req, res) {
+        const { flagId } = req.params
+        const validFlag = commentFlags.findIndex(obj => obj.id == flagId)
+        if (validFlag === -1) {
+            throw res.status(404).send({
+                status: 404,
+                message: "flag does not exist"
+            });
+        }
+        const flgz = commentFlags.filter(obj => obj.commentId == flagId)
+
+        flgz.forEach(f => commentFlags.splice(commentFlags.findIndex(e => e.articleId == f.articleId), 1))
+        comments.splice(validFlag, 1)
+
+        res.json({
+            status: 200,
+            message: 'comment successfully deleted and every thing assiciated'
+
+        })
+    }
+}

--- a/api/v1/routes/admin.js
+++ b/api/v1/routes/admin.js
@@ -1,6 +1,7 @@
 import express from 'express'
 import adminController from '../controllers/adminController'
 import adminIgnoreController from '../controllers/adminIgnoreController'
+import adminDeleteController from '../controllers/adminDeleteController'
 import admin from "../middlewares/adminValidation/admin"
 
 import jwt from "../middlewares/jwt"
@@ -13,5 +14,10 @@ router.get("/admin/comments", jwt, admin, adminController.fetch_comment)
 
 router.delete("/admin/:flagId/ignore/articles", jwt, admin, adminIgnoreController.article)
 router.delete("/admin/:flagId/ignore/comments", jwt, admin, adminIgnoreController.comment)
+
+// --------------- Admin can delete flagged items ----------------
+
+router.delete("/admin/:flagId/delete/articles", jwt, admin, adminDeleteController.article)
+router.delete("/admin/:flagId/delete/comments", jwt, admin, adminDeleteController.comment)
 
 export default router


### PR DESCRIPTION
### What does this PR do ?
- Admin can delete a flagged articles
- Admin can delete a flagged comment
- validations before delete
- delete everything associated
- response to the user
### Description of tasks to be completed ?
Have the following endpoint working
- DELETE /admin/`:flagId`/delete/articles
- DELETE /admin/`:flagId`/delete/comments
### How should this be manually tested ?
After cloning this repo, od into it and run `npm start` in the terminal
- using postman test the above endpoints with this header
key: Content-type value: application/json
- to test authantication, add this to the header: Get TOKEN from login endpoint
key: token value: JWT TOKEN
### Any background context you want to provide ?
N/A
### What are the relevant PivotTracker stories ?
#168388570
#168388529